### PR TITLE
Remove zend classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.2.0 - 2020-01-08
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Removed
+
+- Dependency to zendframework/zend-servicemanager to avoid naming conflict with the rename of Zend to Laminas.
+
 ## 1.1.0 - 2019-09-19
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3",
     "jms/serializer": "^3.2",
-    "symfony/yaml": "^4.2",
-    "zendframework/zend-servicemanager": "^3.0"
+    "psr/container": "^1.0",
+    "symfony/yaml": "^4.2"
   },
   "require-dev": {
     "bluepsyduck/test-helper": "^1.0",
@@ -38,11 +38,6 @@
       "BluePsyduckTest\\FactorioModPortalClient\\": "test/src/",
       "BluePsyduckTestAsset\\FactorioModPortalClient\\": "test/asset/",
       "BluePsyduckTestSerializer\\FactorioModPortalClient\\": "test/serializer/"
-    }
-  },
-  "extra": {
-    "zf": {
-      "config-provider": "BluePsyduck\\FactorioModPortalClient\\ConfigProvider"
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     "guzzlehttp/guzzle": "^6.3",
     "jms/serializer": "^3.2",
     "psr/container": "^1.0",
-    "symfony/yaml": "^4.2"
+    "symfony/yaml": "^4.2 | ^5.0"
   },
   "require-dev": {
     "bluepsyduck/test-helper": "^1.0",
-    "phpstan/phpstan": "^0.11",
-    "phpstan/phpstan-phpunit": "^0.11",
-    "phpstan/phpstan-strict-rules": "^0.11",
+    "phpstan/phpstan": "^0.12",
+    "phpstan/phpstan-phpunit": "^0.12",
+    "phpstan/phpstan-strict-rules": "^0.12",
     "phpunit/phpunit": "^8.0",
-    "rregeer/phpunit-coverage-check": "^0.2",
+    "rregeer/phpunit-coverage-check": "^0.3",
     "squizlabs/php_codesniffer": "^3.3"
   },
   "autoload": {

--- a/config/dependencies.php
+++ b/config/dependencies.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace BluePsyduck\FactorioModPortalClient;
 
 use BluePsyduck\FactorioModPortalClient\Constant\ServiceName;
-use Zend\ServiceManager\Factory\InvokableFactory;
 
 return [
     'dependencies' => [
@@ -21,14 +20,15 @@ return [
             Client\ClientInterface::class => Client\ClientFactory::class,
             Client\Facade::class => Client\FacadeFactory::class,
 
-            Endpoint\FullModEndpoint::class => InvokableFactory::class,
-            Endpoint\ModListEndpoint::class => InvokableFactory::class,
-            Endpoint\ModEndpoint::class => InvokableFactory::class,
-
             Service\EndpointService::class => Service\EndpointServiceFactory::class,
 
             // 3rd party dependencies
             ServiceName::SERIALIZER => Serializer\SerializerFactory::class,
+        ],
+        'invokables' => [
+            Endpoint\FullModEndpoint::class => Endpoint\FullModEndpoint::class,
+            Endpoint\ModListEndpoint::class => Endpoint\ModListEndpoint::class,
+            Endpoint\ModEndpoint::class => Endpoint\ModEndpoint::class,
         ],
     ],
 ];

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,5 +5,5 @@
     <file>./test/serializer</file>
     <file>./test/src</file>
 
-    <rule ref="PSR2" />
+    <rule ref="PSR12" />
 </ruleset>

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -133,8 +133,11 @@ class Client implements ClientInterface
         $endpoint = $this->endpointService->getEndpointForRequest($request);
         $responseContents = $this->getContentsFromMessage($clientResponse);
 
+        /** @var class-string<ResponseInterface> $responseClass */
+        $responseClass = $endpoint->getResponseClass();
+
         try {
-            $result = $this->serializer->deserialize($responseContents, $endpoint->getResponseClass(), 'json');
+            $result = $this->serializer->deserialize($responseContents, $responseClass, 'json');
         } catch (Exception $e) {
             $requestContents = $this->getContentsFromMessage($clientRequest);
             throw new InvalidResponseException($e->getMessage(), $requestContents, $responseContents, $e);
@@ -192,10 +195,10 @@ class Client implements ClientInterface
 
         try {
             $responseContents = $this->getContentsFromMessage($exception->getResponse());
+
+            /* @var ErrorResponse $errorResponse */
             $errorResponse = $this->serializer->deserialize($responseContents, ErrorResponse::class, 'json');
-            if ($errorResponse instanceof ErrorResponse) {
-                $result = $errorResponse->getMessage();
-            }
+            $result = $errorResponse->getMessage();
         } catch (Exception $e) {
             // Failed to fetch message from error response.
         }

--- a/src/Client/ClientFactory.php
+++ b/src/Client/ClientFactory.php
@@ -6,8 +6,7 @@ namespace BluePsyduck\FactorioModPortalClient\Client;
 
 use BluePsyduck\FactorioModPortalClient\Constant\ServiceName;
 use BluePsyduck\FactorioModPortalClient\Service\EndpointService;
-use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * The factory for the client.
@@ -15,7 +14,7 @@ use Zend\ServiceManager\Factory\FactoryInterface;
  * @author BluePsyduck <bluepsyduck@gmx.com>
  * @license http://opensource.org/licenses/GPL-3.0 GPL v3
  */
-class ClientFactory implements FactoryInterface
+class ClientFactory
 {
     /**
      * Creates the client.

--- a/src/Client/ClientFactory.php
+++ b/src/Client/ClientFactory.php
@@ -20,7 +20,7 @@ class ClientFactory
      * Creates the client.
      * @param  ContainerInterface $container
      * @param  string $requestedName
-     * @param  null|array $options
+     * @param  array<mixed>|null $options
      * @return Client
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): Client

--- a/src/Client/FacadeFactory.php
+++ b/src/Client/FacadeFactory.php
@@ -18,7 +18,7 @@ class FacadeFactory
      * Creates the client.
      * @param  ContainerInterface $container
      * @param  string $requestedName
-     * @param  null|array $options
+     * @param  array<mixed>|null $options
      * @return Facade
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): Facade

--- a/src/Client/FacadeFactory.php
+++ b/src/Client/FacadeFactory.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace BluePsyduck\FactorioModPortalClient\Client;
 
-use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * The factory of the facade.
@@ -13,7 +12,7 @@ use Zend\ServiceManager\Factory\FactoryInterface;
  * @author BluePsyduck <bluepsyduck@gmx.com>
  * @license http://opensource.org/licenses/GPL-3.0 GPL v3
  */
-class FacadeFactory implements FactoryInterface
+class FacadeFactory
 {
     /**
      * Creates the client.

--- a/src/Client/OptionsFactory.php
+++ b/src/Client/OptionsFactory.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace BluePsyduck\FactorioModPortalClient\Client;
 
 use BluePsyduck\FactorioModPortalClient\Constant\ConfigKey;
-use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * The factory of the options.
@@ -14,7 +13,7 @@ use Zend\ServiceManager\Factory\FactoryInterface;
  * @author BluePsyduck <bluepsyduck@gmx.com>
  * @license http://opensource.org/licenses/GPL-3.0 GPL v3
  */
-class OptionsFactory implements FactoryInterface
+class OptionsFactory
 {
     /**
      * Creates the options.

--- a/src/Client/OptionsFactory.php
+++ b/src/Client/OptionsFactory.php
@@ -19,7 +19,7 @@ class OptionsFactory
      * Creates the options.
      * @param  ContainerInterface $container
      * @param  string $requestedName
-     * @param  null|array $options
+     * @param  array<mixed>|null $options
      * @return Options
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): Options

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -14,7 +14,7 @@ class ConfigProvider
 {
     /**
      * Returns the configuration of the library.
-     * @return array
+     * @return array<mixed>
      */
     public function __invoke(): array
     {

--- a/src/Serializer/Construction/ObjectConstructor.php
+++ b/src/Serializer/Construction/ObjectConstructor.php
@@ -22,7 +22,7 @@ class ObjectConstructor implements ObjectConstructorInterface
      * @param DeserializationVisitorInterface $visitor
      * @param ClassMetadata $metadata
      * @param mixed $data
-     * @param array $type
+     * @param array<mixed> $type
      * @param DeserializationContext $context
      * @return object|null
      */

--- a/src/Serializer/Handler/SimpleDateTimeHandler.php
+++ b/src/Serializer/Handler/SimpleDateTimeHandler.php
@@ -21,7 +21,7 @@ class SimpleDateTimeHandler implements SubscribingHandlerInterface
 {
     /**
      * Returns the methods to subscribe to.
-     * @return array
+     * @return array<mixed>
      */
     public static function getSubscribingMethods()
     {
@@ -39,7 +39,7 @@ class SimpleDateTimeHandler implements SubscribingHandlerInterface
      * Deserializes the datetime, using its constructor.
      * @param DeserializationVisitorInterface $visitor
      * @param mixed $data
-     * @param array $type
+     * @param array|string[] $type
      * @return DateTimeInterface|null
      * @throws Exception
      */

--- a/src/Serializer/SerializerFactory.php
+++ b/src/Serializer/SerializerFactory.php
@@ -7,11 +7,10 @@ namespace BluePsyduck\FactorioModPortalClient\Serializer;
 use BluePsyduck\FactorioModPortalClient\Constant\ConfigKey;
 use BluePsyduck\FactorioModPortalClient\Serializer\Construction\ObjectConstructor;
 use BluePsyduck\FactorioModPortalClient\Serializer\Handler\SimpleDateTimeHandler;
-use Interop\Container\ContainerInterface;
 use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\SerializerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * The factory for the JMS serializer.
@@ -19,7 +18,7 @@ use Zend\ServiceManager\Factory\FactoryInterface;
  * @author BluePsyduck <bluepsyduck@gmx.com>
  * @license http://opensource.org/licenses/GPL-3.0 GPL v3
  */
-class SerializerFactory implements FactoryInterface
+class SerializerFactory
 {
     /**
      * Creates the serializer.

--- a/src/Serializer/SerializerFactory.php
+++ b/src/Serializer/SerializerFactory.php
@@ -24,7 +24,7 @@ class SerializerFactory
      * Creates the serializer.
      * @param ContainerInterface $container
      * @param string $requestedName
-     * @param array|null $options
+     * @param  array<mixed>|null $options
      * @return SerializerInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): SerializerInterface

--- a/src/Service/EndpointServiceFactory.php
+++ b/src/Service/EndpointServiceFactory.php
@@ -20,7 +20,7 @@ class EndpointServiceFactory
      * Creates the service.
      * @param  ContainerInterface $container
      * @param  string $requestedName
-     * @param  null|array $options
+     * @param  array<mixed>|null $options
      * @return EndpointService
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): EndpointService

--- a/src/Service/EndpointServiceFactory.php
+++ b/src/Service/EndpointServiceFactory.php
@@ -6,8 +6,7 @@ namespace BluePsyduck\FactorioModPortalClient\Service;
 
 use BluePsyduck\FactorioModPortalClient\Constant\ConfigKey;
 use BluePsyduck\FactorioModPortalClient\Endpoint\EndpointInterface;
-use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * The factory of the endpoint service.
@@ -15,7 +14,7 @@ use Zend\ServiceManager\Factory\FactoryInterface;
  * @author BluePsyduck <bluepsyduck@gmx.com>
  * @license http://opensource.org/licenses/GPL-3.0 GPL v3
  */
-class EndpointServiceFactory implements FactoryInterface
+class EndpointServiceFactory
 {
     /**
      * Creates the service.

--- a/test/asset/SerializerTestCase.php
+++ b/test/asset/SerializerTestCase.php
@@ -20,7 +20,7 @@ class SerializerTestCase extends TestCase
 {
     /**
      * Asserts that deserializing the data to the object actually equals the object.
-     * @param array $serializedData
+     * @param array<mixed> $serializedData
      * @param object $expectedObject
      */
     protected function assertDeserializedObject(array $serializedData, object $expectedObject): void

--- a/test/asset/SerializerTestCase.php
+++ b/test/asset/SerializerTestCase.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace BluePsyduckTestAsset\FactorioModPortalClient;
 
 use BluePsyduck\FactorioModPortalClient\Serializer\SerializerFactory;
-use Interop\Container\ContainerInterface;
 use JMS\Serializer\SerializerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 /**
  * The test case for testing serializing of data.

--- a/test/src/Client/ClientFactoryTest.php
+++ b/test/src/Client/ClientFactoryTest.php
@@ -9,10 +9,10 @@ use BluePsyduck\FactorioModPortalClient\Client\ClientFactory;
 use BluePsyduck\FactorioModPortalClient\Client\Options;
 use BluePsyduck\FactorioModPortalClient\Constant\ServiceName;
 use BluePsyduck\FactorioModPortalClient\Service\EndpointService;
-use Interop\Container\ContainerInterface;
 use JMS\Serializer\SerializerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 /**
  * The PHPUnit test of the ClientFactory class.

--- a/test/src/Client/ClientTest.php
+++ b/test/src/Client/ClientTest.php
@@ -81,7 +81,7 @@ class ClientTest extends TestCase
 
     /**
      * Creates and returns a mocked client.
-     * @param array $methods
+     * @param array|string[] $methods
      * @return Client|MockObject
      */
     protected function createMockedClient(array $methods): Client
@@ -171,7 +171,7 @@ class ClientTest extends TestCase
         $promise1->expects($this->once())
                  ->method('then')
                  ->with(
-                     $this->callback(function ($callback) use ($clientResponse, $response) {
+                     $this->callback(function ($callback) use ($clientResponse, $response): bool {
                          $this->assertIsCallable($callback);
 
                          $result = $callback($clientResponse);
@@ -179,7 +179,7 @@ class ClientTest extends TestCase
 
                          return true;
                      }),
-                     $this->callback(function ($callback) use ($requestException) {
+                     $this->callback(function ($callback) use ($requestException): bool {
                          $this->assertIsCallable($callback);
 
                          $callback($requestException);

--- a/test/src/Client/FacadeFactoryTest.php
+++ b/test/src/Client/FacadeFactoryTest.php
@@ -7,9 +7,9 @@ namespace BluePsyduckTest\FactorioModPortalClient\Client;
 use BluePsyduck\FactorioModPortalClient\Client\ClientInterface;
 use BluePsyduck\FactorioModPortalClient\Client\Facade;
 use BluePsyduck\FactorioModPortalClient\Client\FacadeFactory;
-use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 /**
  * The PHPUnit test of the FacadeFactory class.

--- a/test/src/Client/OptionsFactoryTest.php
+++ b/test/src/Client/OptionsFactoryTest.php
@@ -7,9 +7,9 @@ namespace BluePsyduckTest\FactorioModPortalClient\Client;
 use BluePsyduck\FactorioModPortalClient\Client\Options;
 use BluePsyduck\FactorioModPortalClient\Client\OptionsFactory;
 use BluePsyduck\FactorioModPortalClient\Constant\ConfigKey;
-use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 
 /**
  * The PHPUnit test of the OptionsFactory class.

--- a/test/src/Serializer/SerializerFactoryTest.php
+++ b/test/src/Serializer/SerializerFactoryTest.php
@@ -9,12 +9,12 @@ use BluePsyduck\FactorioModPortalClient\Serializer\Construction\ObjectConstructo
 use BluePsyduck\FactorioModPortalClient\Serializer\Handler\SimpleDateTimeHandler;
 use BluePsyduck\FactorioModPortalClient\Serializer\SerializerFactory;
 use BluePsyduck\TestHelper\ReflectionTrait;
-use Interop\Container\ContainerInterface;
 use JMS\Serializer\Handler\HandlerRegistry;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\SerializerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use ReflectionException;
 
 /**

--- a/test/src/Service/EndpointServiceFactoryTest.php
+++ b/test/src/Service/EndpointServiceFactoryTest.php
@@ -9,9 +9,9 @@ use BluePsyduck\FactorioModPortalClient\Endpoint\EndpointInterface;
 use BluePsyduck\FactorioModPortalClient\Service\EndpointService;
 use BluePsyduck\FactorioModPortalClient\Service\EndpointServiceFactory;
 use BluePsyduck\TestHelper\ReflectionTrait;
-use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use ReflectionException;
 
 /**


### PR DESCRIPTION
This removes the dependency to zendframework/zend-servicemanager to avoid naming conflict with the rename of Zend to Laminas.